### PR TITLE
refactor : operator가 나갈 시 방의 operator가 없도록

### DIFF
--- a/srcs/commands/Part.cpp
+++ b/srcs/commands/Part.cpp
@@ -31,13 +31,6 @@ void Command::part(int fd, std::vector<std::string> command_vec)
 				_server.removeChannel(channel->getChannelName());
 				delete channel;
 			}
-			else
-			{
-				std::vector<int> fdList = channel->getClientFdList();
-				std::vector<int>::iterator fd_iter = fdList.begin();
-				fd_iter++;
-				channel->addOperatorFd(*fd_iter);
-			}
 		}
 		else
 		{

--- a/srcs/commands/Quit.cpp
+++ b/srcs/commands/Quit.cpp
@@ -20,16 +20,8 @@ void Command::quit(int fd, std::vector<std::string> command_vec)
 			_server.removeChannel(channel->getChannelName());
 			delete channel;
 		}
-		else
-		{
-			std::vector<int> fdList = channel->getClientFdList();
-			std::vector<int>::iterator fd_iter = fdList.begin();
-			fd_iter++;
-			channel->addOperatorFd(*fd_iter);
-		}
 	}
-	// Client *client = client_iter->second;
 	client_iter->second->clearClient();
 	clients.erase(fd);
-	// delete client;
+	close(fd);
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - operator가 나갈 시 방의 operator가 없어지도록수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - part,quit에서 operator를 넘기는 부분 삭제